### PR TITLE
Add Hetex.hx to the list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Helix is a post-modern modal text editor with built-in support for multiple sele
 
 - [ghost-text.hx](https://github.com/nik-rev/ghost-text.hx) - GhostText implementation allowing you to edit text in your browser using Helix.
 - [helix-file-watcher](https://github.com/mattwparas/helix-file-watcher) - A plugin that monitors the current directory for file changes.
+- [HeTeX.hx](https://github.com/daynardn/HeTeX.hx) - An experimental plugin for rendering LaTeX as ASCII within Helix.
 - [scooter.hx](https://github.com/thomasschafer/scooter.hx) - Scooter.hx is a find-and-replace plugin for Helix.
 - [smooth-scroll.hx](https://github.com/thomasschafer/smooth-scroll.hx) - Smooth scrolling Helix plugin.
 - [Steel Dart LSP Extension](https://github.com/mattwparas/steel/discussions/416#discussioncomment-13489298) - Dart LSP extension using Steel programming language.


### PR DESCRIPTION
This plugin renders LaTeX as ASCII within helix by echoing the output which helix renders as a textbox. It also copies a c LaTeX -> ASCII binary to a temp directory that it then makes it executable which might cause issues on some systems.

It's has some issues, but since it's the only plugin to render LaTeX so far I wanted to see if it could be merged.
