### PR TITLE
Add IWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Tools and Utilities
 
+- [IWE](https://github.com/iwe-org/iwe) - LSP server for markdown knowledge management with go-to-definition, backlinks, link completion, and code actions.
 - [Steel](https://github.com/mattwparas/steel) - Scheme-based scripting language for configuration and extensibility.
 - [yazelix](https://github.com/luccahuguet/yazelix) - Integrates Yazi, Zellij, and Helix for an IDE-like experience with a file tree.
 


### PR DESCRIPTION
IWE provides an LSP server for markdown-based knowledge management that works natively with Helix via languages.toml configuration.

Features: go-to-definition, find references (backlinks), link autocompletion, code actions (extract/inline), hover preview, and inlay hints.

Built in Rust, actively maintained, Apache-2.0 license.

GitHub: https://github.com/iwe-org/iwe