### PR TITLE
Add helix-fcitx-focus plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [csharp-hx](https://github.com/jdrst/csharp-hx) - C# language support and tooling for Helix.
 - [flash.hx](https://github.com/shybovycha/flash.hx) - Jumping around screen using prefix search, like [flash.nvim](https://github.com/folke/flash.nvim).
 - [helix-file-watcher](https://github.com/mattwparas/helix-file-watcher) - Monitors the current directory for file changes.
+- [helix-fcitx-focus](https://github.com/mtul0729/helix-fcitx-focus) - Helix Steel plugin that manages fcitx5 input method state across mode and focus changes.
 - [helix-lsp-config](https://github.com/helix-editor/helix/wiki/Language-Server-Configurations) - Community-maintained LSP configurations.
 - [HeTeX.hx](https://github.com/daynardn/HeTeX.hx) - Experimental plugin for rendering LaTeX as ASCII within Helix.
 - [hx-tmux-navigator](https://github.com/piotrkwarcinski/hx-tmux-navigator) - Navigate seamlessly between Helix and tmux panes.


### PR DESCRIPTION
Adds helix-fcitx-focus to the Plugins section. It is a Helix Steel plugin for managing fcitx5 input method state across mode and focus changes.