### PR TITLE
Add hxwiki, a VimWiki-inspired Steel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [helix-lsp-config](https://github.com/helix-editor/helix/wiki/Language-Server-Configurations) - Community-maintained LSP configurations.
 - [HeTeX.hx](https://github.com/daynardn/HeTeX.hx) - Experimental plugin for rendering LaTeX as ASCII within Helix.
 - [hx-tmux-navigator](https://github.com/piotrkwarcinski/hx-tmux-navigator) - Navigate seamlessly between Helix and tmux panes.
+- [hxwiki](https://github.com/sipmann/hxwiki) - VimWiki-inspired Steel plugin for following/creating `[[links]]` and a daily diary.
 - [microscope.hx](https://github.com/chuwy/microscope.hx) - Customizable pickers, like [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
 - [modeline.hx](https://codeberg.org/gwid/modeline.hx) - Support for basic Emacs and Vim modelines.
 - [notify.hx](https://github.com/chuwy/notify.hx) - Notification popup engine for Helix.


### PR DESCRIPTION
## Summary

Adds [hxwiki](https://github.com/sipmann/hxwiki) to the Plugins section: a VimWiki-inspired Helix Steel plugin that lets you follow/create `[[wiki-links]]` between Markdown notes and keep a daily diary, without leaving the editor.

- Alphabetically placed between `hx-tmux-navigator` and `microscope.hx`.
- Checked the list for existing wiki/note-taking entries first — the only other "wiki" hits are links to Helix's own GitHub wiki (LSP configs, themes), so this isn't a duplicate.

## Test plan

- [x] Follows the `[Name](link) - Description.` format from CONTRIBUTING.md
- [x] Placed in alphabetical order within the Plugins section
- [x] One item per PR