### PR TITLE
Add vim.hx to plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [streal.hx](https://github.com/gllms/streal.hx) - Bookmark files and quickly switch between them.
 - [switcheroo.hx](https://github.com/godalming123/switcheroo.hx) - Switch between .cpp and .h files with the same base name.
 - [trail.hx](https://github.com/Ra77a3l3-jar/trail.hx) - A recent projects picker.
+- [vim.hx](https://github.com/mattwparas/vim.hx) - Vim bindings for Helix.
 - [wakatime.hx](https://github.com/Xerxes-2/wakatime.hx) - A Helix Steel plugin that sends WakaTime heartbeats.
 - [zen-mode.hx](https://github.com/notnmeyer/zen-mode.hx) - Distraction free coding. Center your content, hide portions of the UI.
 


### PR DESCRIPTION
Adds vim.hx (https://github.com/mattwparas/vim.hx), a plugin that brings Vim bindings to Helix, by the same author as steel-pty and helix-file-watcher.

Related discussion: https://github.com/helix-editor/helix/pull/8675